### PR TITLE
Add phpenv-man plugin by default

### DIFF
--- a/bin/phpenv-installer
+++ b/bin/phpenv-installer
@@ -157,5 +157,6 @@ test_deps
 install_phpenv
 install_plugin "php-build/php-build"
 install_plugin "madumlao/phpenv-aliases"
+install_plugin "madumlao/phpenv-man"
 install_plugin "ngyuki/phpenv-composer"
 test_if_phpenv_is_in_path


### PR DESCRIPTION
phpenv-man is a plugin for viewing the man pages of installed php programs, e.g.

~~~
phpenv man php
~~~

or 

~~~
phpenv man phar
~~~

This will automatically pull the man pages from the enabled php prefix.